### PR TITLE
Return Default [0x0409] for Invalid Language Descriptor

### DIFF
--- a/src/usbx/_windows/winregistry.py
+++ b/src/usbx/_windows/winregistry.py
@@ -165,6 +165,8 @@ class WindowsDeviceRegistry(DeviceRegistryBase):
         try:
             langs = self.get_descriptor(hub_handle, usb_port_num, 3, 0, 0)
             num_langs = (len(langs) - 2) // 2
+            if num_langs < 0:
+                return [0x0409]
             return struct.unpack(f'<{num_langs}H', langs[2:])
         except WindowsError:
             return [0x0409]


### PR DESCRIPTION
When the language descriptor is an empty byte string `b""`, `struct.unpack()` throws an error, but it's not captured by the `except WindowsError` handler. This doesn't crash the program, but it does print a traceback to the console for every device with this problem.

If the number of languages is 0, the default 0x0409 for US English is returned just like the exception case.